### PR TITLE
Allow optional collapsing of thumbnail container

### DIFF
--- a/javascripts/discourse/templates/topic-list-thumbnail.hbr
+++ b/javascripts/discourse/templates/topic-list-thumbnail.hbr
@@ -1,5 +1,9 @@
 {{#if view.shouldDisplay}}
-  <div class="topic-list-thumbnail">
+  {{#if view.hasThumbnail}}
+    <div class="topic-list-thumbnail has-thumbnail">
+  {{else}}
+    <div class="topic-list-thumbnail no-thumbnail">
+  {{/if}}
     <a href="{{view.url}}">
       {{#if view.hasThumbnail}}
         <img class="background-thumbnail" 


### PR DESCRIPTION
Add pseudo-classes to allow the optional collapsing of thumbnail container via CSS override, if no thumbnail available for the topic.

See also:

https://meta.discourse.org/t/topic-list-thumbnails-theme-component/150602/102?u=terrapop