### PR TITLE
FEATURE: Disable thumbnails for non-topic-list views by default

### DIFF
--- a/javascripts/discourse/services/topic-thumbnails.js
+++ b/javascripts/discourse/services/topic-thumbnails.js
@@ -22,6 +22,14 @@ const masonryTags = settings.masonry_tags.split("|");
 export default Service.extend({
   router: service("router"),
 
+  @discourseComputed("router.currentRouteName")
+  isTopicListRoute(currentRouteName) {
+    return (
+      currentRouteName.match(/^discovery\./) ||
+      currentRouteName.match(/^tags?\.show/)
+    );
+  },
+
   @discourseComputed(
     "router.currentRouteName",
     "router.currentRoute.attributes.category.id"
@@ -43,9 +51,15 @@ export default Service.extend({
   @discourseComputed(
     "viewingCategoryId",
     "viewingTagId",
-    "router.currentRoute.metadata.customThumbnailMode"
+    "router.currentRoute.metadata.customThumbnailMode",
+    "isTopicListRoute"
   )
-  displayMode(viewingCategoryId, viewingTagId, customThumbnailMode) {
+  displayMode(
+    viewingCategoryId,
+    viewingTagId,
+    customThumbnailMode,
+    isTopicListRoute
+  ) {
     if (customThumbnailMode) return customThumbnailMode;
 
     if (masonryCategories.includes(viewingCategoryId)) {
@@ -60,8 +74,10 @@ export default Service.extend({
       return "grid";
     } else if (listTags.includes(viewingTagId)) {
       return "list";
-    } else {
+    } else if (isTopicListRoute || settings.enable_outside_topic_lists) {
       return settings.default_thumbnail_mode;
+    } else {
+      return "none";
     }
   },
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -9,5 +9,6 @@ en:
       grid_tags: The grid view will be used for these tags
       masonry_tags: The masonry view will be used for these tags
       list_tags: The list view will be used for these tags
+      enable_outside_topic_lists: Enable thumbnails on non-topic-list pages (e.g. user activity, personal messages, suggested topics)
       placeholder_icon: Icon to display on topics without thumbnail images
       mobile_thumbnails: Enable thumbnails on mobile devices

--- a/settings.yml
+++ b/settings.yml
@@ -37,6 +37,8 @@ list_tags:
   list_type: tag
   default: ""
 
+enable_outside_topic_lists: false
+
 placeholder_icon:
   default: "comments"
 


### PR DESCRIPTION
The majority of sites don't want this view enabled for non-topic-list
pages. This commit adds a new theme setting to control it, and sets the
default to false.