### PR TITLE
FIX: Add workaround for core raw-view class regression

### DIFF
--- a/javascripts/discourse/initializers/topic-thumbnails-init.js
+++ b/javascripts/discourse/initializers/topic-thumbnails-init.js
@@ -11,7 +11,18 @@ import {
 export default {
   name: "topic-thumbnails-init",
   initialize() {
+    this.applyViewClassWorkaround();
     withPluginApi("0.8.7", (api) => this.initWithApi(api));
+  },
+
+  applyViewClassWorkaround() {
+    // Workaround for https://github.com/discourse/discourse/pull/12685
+    // Can be removed once that has been merged, and sites have had time to update
+    const viewClassKey = Object.keys(requirejs.entries).find((k) =>
+      k.endsWith("raw-views/topic-list-thumbnail")
+    );
+    requirejs.entries["discourse/raw-views/topic-list-thumbnail"] =
+      requirejs.entries[viewClassKey];
   },
 
   initWithApi(api) {


### PR DESCRIPTION
A fix is [pending in core](https://github.com/discourse/discourse/pull/12685), but this workaround will allow this theme component to function in the meantime