### PR TITLE
FIX: Pin icon should update when pin is toggled in topic lists

### DIFF
--- a/javascripts/discourse/initializers/topic-thumbnails-init.js
+++ b/javascripts/discourse/initializers/topic-thumbnails-init.js
@@ -47,6 +47,7 @@ export default {
 
       // Hack to disable the mobile topic-list-item template
       // Our grid styling is responsive, and uses the desktop HTML structure
+      @observes("topic.pinned")
       renderTopicListItem() {
         const wasMobileView = getResolverOption("mobileView");
         if (


### PR DESCRIPTION
This component overrides core's method `renderTopicListItem` which has an `@observes` decorator for `topic.pinned` so that the UI updates when the user toggles the pin for a topic in a topics list. However, the method override in this component doesn't apply the same decorator to the override which effectively removes the decorator entirely and that causes the UI not to update when the pin is toggled.

https://github.com/discourse/discourse/blob/810e040f170813fdff9727bf6e145824ad6f14eb/app/assets/javascripts/discourse/app/components/topic-list-item.js#L49-L53

Related meta topic: https://meta.discourse.org/t/cant-pin-unpin-topic-from-the-title/213444?u=osama.