### PR TITLE
FIX: Correct srcset attribute syntax

### DIFF
--- a/javascripts/discourse/templates/topic-list-thumbnail.hbr
+++ b/javascripts/discourse/templates/topic-list-thumbnail.hbr
@@ -5,20 +5,20 @@
   {{else}}
     <div class="topic-list-thumbnail no-thumbnail">
   {{/if}}
-      <a href={{view.url}}>
+      <a href="{{view.url}}">
         {{#if view.hasThumbnail}}
           <img
             class="background-thumbnail"
-            src={{view.fallbackSrc}}
-            srcset={{view.srcSet}}
+            src="{{view.fallbackSrc}}"
+            srcset="{{view.srcSet}}"
             width={{view.width}}
             height={{view.height}}
             loading="lazy"
           >
           <img
             class="main-thumbnail"
-            src={{view.fallbackSrc}}
-            srcset={{view.srcSet}}
+            src="{{view.fallbackSrc}}"
+            srcset="{{view.srcSet}}"
             width={{view.width}}
             height={{view.height}}
             loading="lazy"


### PR DESCRIPTION
This regressed in 21a7b38fed. Raw handlebars templates do not automatically quote attribute values