### PR TITLE
FIX: remove CSS masonry @supports due to Safari issues

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -178,6 +178,7 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+    min-width: 0;
   }
 
   .num.activity {
@@ -192,36 +193,6 @@
     a {
       padding: 0;
       margin-top: auto;
-    }
-  }
-}
-
-@supports (grid-template-rows: masonry) {
-  .topic-thumbnails-masonry {
-    .topic-list-body {
-      grid-template-rows: masonry;
-    }
-
-    .topic-list-item {
-      height: auto;
-    }
-
-    .topic-list-thumbnail {
-      float: none;
-      width: 100%;
-      min-height: 150px;
-      max-height: 500px;
-
-      .background-thumbnail {
-        display: absolute;
-        height: calc(200%);
-      }
-
-      .main-thumbnail {
-        position: relative;
-        width: 100%;
-        max-height: 100%;
-      }
     }
   }
 }
@@ -352,9 +323,8 @@
   }
 }
 
-@supports not (grid-template-rows: masonry) {
-  .topic-thumbnails-masonry {
-    /*
+.topic-thumbnails-masonry {
+  /*
     Variables set by javascript:
     --masonry-num-columns
     --masonry-tallest-column
@@ -362,27 +332,26 @@
     --masonry-column-width
   */
 
-    position: relative;
-    height: var(--masonry-tallest-column);
+  position: relative;
+  height: var(--masonry-tallest-column);
 
-    .topic-list-item {
-      /*
+  .topic-list-item {
+    /*
       Variables set by javascript:
       --masonry-height 
       --masonry-height-above  
       --masonry-column-index
     */
 
-      position: absolute;
+    position: absolute;
 
-      height: var(--masonry-height);
-      width: var(--masonry-column-width);
+    height: var(--masonry-height);
+    width: var(--masonry-column-width);
 
-      left: calc(
-        (var(--masonry-column-width) + var(--masonry-grid-spacing)) *
-          var(--masonry-column-index)
-      );
-      top: var(--masonry-height-above);
-    }
+    left: calc(
+      (var(--masonry-column-width) + var(--masonry-grid-spacing)) *
+        var(--masonry-column-index)
+    );
+    top: var(--masonry-height-above);
   }
 }


### PR DESCRIPTION
See the issues reported here: https://meta.discourse.org/t/topic-list-thumbnails/150602/281?u=awesomerobot

When the screen is resized in masonry mode, images overlap in Safari. 

It seems that Safari thinks it supports masonry and is applying the styles within  `@supports (grid-template-rows: masonry)`, which is mostly breaking the layout. 

Since this feature is basically non-existent per https://caniuse.com/mdn-css_properties_grid-template-rows_masonry 😢, it seems like we should remove this detection for now. This gets the masonry option properly working in Safari again. 

Before:


![Screenshot 2023-04-28 at 3 22 26 PM](https://user-images.githubusercontent.com/1681963/235235195-950fbf63-b76d-4772-b921-3cafe41f39fb.png)


After:

![Screenshot 2023-04-28 at 3 22 38 PM](https://user-images.githubusercontent.com/1681963/235235199-d9bde74e-1676-485c-8778-1f97f92dc814.png)