### PR TITLE
UX: improve mobile list mode layout

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -6,11 +6,25 @@
 .topic-thumbnails-list {
   .topic-list-body .topic-list-item {
     .right {
-      grid-template-columns: 15% 65% 20%;
-      grid-template-rows: 15% 40% 45%;
+      display: grid;
+      grid-template-columns: 15% auto 15%;
       grid-template-areas: "thumbnail title replies" "thumbnail data data";
+      gap: 0 0.5em;
+      .num {
+        text-align: right;
+      }
       .topic-list-thumbnail {
         grid-area: thumbnail;
+      }
+      .main-link {
+        grid-area: title;
+        width: unset;
+      }
+      .topic-item-stats {
+        grid-area: data;
+      }
+      .pull-right {
+        grid-area: replies;
       }
     }
   }


### PR DESCRIPTION
Seems like this styling was a little incomplete: 

Before:
![Screenshot 2023-06-14 at 5 19 27 PM](https://github.com/discourse/discourse-topic-thumbnails/assets/1681963/35cf54a3-9ed7-498e-ac80-9ad42cf3a5bf)


After:
![Screenshot 2023-06-14 at 5 17 51 PM](https://github.com/discourse/discourse-topic-thumbnails/assets/1681963/aea83923-03c2-4f55-af67-cfeae4f0ffc0)

Reported in https://meta.discourse.org/t/topics-list-in-mobile-view-excerpt-overflows-and-count-date-wraps/260396
