### PR TITLE
FEATURE: Add a blog style layout to the thumbnail options

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -331,7 +331,7 @@
 
   .topic-list-body {
     display: grid;
-    grid-template-columns: repeat( auto-fit, minmax(48%, 1fr) );
+    grid-template-columns: repeat(auto-fit, minmax(48%, 1fr));
     grid-column-gap: 1.5em;
     grid-row-gap: 1.5em;
     border: 0;
@@ -382,7 +382,7 @@
   .topic-list-data:last-of-type {
     display: none;
   }
-  
+
   .topic-thumbnail-blog-data-likes,
   .topic-thumbnail-blog-data-comments,
   .topic-thumbnail-blog-data-views,

--- a/common/common.scss
+++ b/common/common.scss
@@ -199,7 +199,7 @@
 }
 
 .topic-thumbnails-minimal,
-.topic-thumbnails-blog-style-grid  {
+.topic-thumbnails-blog-style-grid {
   margin-top: 5px;
 
   .topic-list-header,
@@ -325,7 +325,7 @@
   }
 }
 
-.topic-thumbnails-blog-style-grid { 
+.topic-thumbnails-blog-style-grid {
   .topic-list-body {
     display: grid;
     grid-template-columns: 48% 48%;
@@ -337,10 +337,11 @@
   .topic-list-item {
     height: auto;
     grid-template-rows: 200px auto min-content min-content;
-    grid-template-areas: "image image image"
-    "content content content"
-    "data data data"
-    "activity activity activity";
+    grid-template-areas:
+      "image image image"
+      "content content content"
+      "data data data"
+      "activity activity activity";
   }
 
   .main-link {

--- a/common/common.scss
+++ b/common/common.scss
@@ -345,6 +345,12 @@
 
   .main-link {
     grid-area: content;
+    .docs-topic-link {
+      display: unset;
+    }
+    .link-top-line {
+      color: var(--tertiary);
+    }
   }
   .link-bottom-line {
     display: block;

--- a/common/common.scss
+++ b/common/common.scss
@@ -5,7 +5,8 @@
 .topic-thumbnails-list,
 .topic-thumbnails-grid,
 .topic-thumbnails-masonry,
-.topic-thumbnails-minimal {
+.topic-thumbnails-minimal,
+.topic-thumbnails-blog-style-grid {
   .topic-list-thumbnail {
     background: var(--primary-low);
     position: relative;
@@ -197,7 +198,8 @@
   }
 }
 
-.topic-thumbnails-minimal {
+.topic-thumbnails-minimal,
+.topic-thumbnails-blog-style-grid  {
   margin-top: 5px;
 
   .topic-list-header,
@@ -320,6 +322,38 @@
         padding: 0 !important;
       }
     }
+  }
+}
+
+.topic-thumbnails-blog-style-grid { 
+  .topic-list-body {
+    display: grid;
+    grid-template-columns: 45% 45%;
+    grid-column-gap: 1.5em;
+    grid-row-gap: 1.5em;
+    border: 0;
+  }
+
+  .topic-list-item {
+    height: 350px;
+    grid-template-rows: 200px auto 15px;
+    grid-template-areas: "image image image"
+    "content content content"
+    "data data data";
+  }
+
+  .topic-thumbnail-likes {
+    grid-area: data;
+    grid-column-start: 0;
+  }
+
+  .main-link {
+    grid-area: content;
+  }
+
+  .topic-excerpt {
+    display: block;
+    font-weight: normal;
   }
 }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -328,32 +328,74 @@
 .topic-thumbnails-blog-style-grid { 
   .topic-list-body {
     display: grid;
-    grid-template-columns: 45% 45%;
+    grid-template-columns: 48% 48%;
     grid-column-gap: 1.5em;
     grid-row-gap: 1.5em;
     border: 0;
   }
 
   .topic-list-item {
-    height: 350px;
-    grid-template-rows: 200px auto 15px;
+    height: auto;
+    grid-template-rows: 200px auto min-content min-content;
     grid-template-areas: "image image image"
     "content content content"
-    "data data data";
-  }
-
-  .topic-thumbnail-likes {
-    grid-area: data;
-    grid-column-start: 0;
+    "data data data"
+    "activity activity activity";
   }
 
   .main-link {
     grid-area: content;
   }
+  .link-bottom-line {
+    display: block;
+    .badge-wrapper {
+      display: none;
+    }
+  }
 
   .topic-excerpt {
     display: block;
     font-weight: normal;
+  }
+
+  .topic-thumbnail-blog-data {
+    grid-area: data;
+    display: flex;
+    align-items: flex-start;
+    gap: 1em;
+  }
+
+  .topic-thumbnail-blog-data-activity {
+    display: block;
+  }
+
+  .topic-list-data:last-of-type {
+    display: none;
+  }
+
+  .topic-thumbnail-blog-data-likes,
+  .topic-thumbnail-blog-data-comments,
+  .topic-thumbnail-blog-data-views,
+  .topic-thumbnail-blog-data-activity {
+    grid-area: likes;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    color: var(--primary-low-mid);
+    width: auto;
+    .number {
+      font-size: 13px;
+      font-weight: bold;
+    }
+    .d-icon {
+      font-size: 13px;
+      margin-right: 0.5em;
+    }
+    a {
+      color: var(--primary-low-mid);
+      font-size: 13px;
+      font-weight: bold;
+    }
   }
 }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -311,7 +311,6 @@
     justify-content: center;
     font-weight: 600;
     width: 100%;
-    overflow: hidden;
     .link-top-line {
       white-space: nowrap;
       overflow: hidden;
@@ -326,9 +325,13 @@
 }
 
 .topic-thumbnails-blog-style-grid {
+  .num.posts-map {
+    display: none;
+  }
+
   .topic-list-body {
     display: grid;
-    grid-template-columns: 48% 48%;
+    grid-template-columns: repeat( auto-fit, minmax(48%, 1fr) );
     grid-column-gap: 1.5em;
     grid-row-gap: 1.5em;
     border: 0;
@@ -379,7 +382,7 @@
   .topic-list-data:last-of-type {
     display: none;
   }
-
+  
   .topic-thumbnail-blog-data-likes,
   .topic-thumbnail-blog-data-comments,
   .topic-thumbnail-blog-data-views,
@@ -391,16 +394,16 @@
     color: var(--primary-low-mid);
     width: auto;
     .number {
-      font-size: 13px;
+      font-size: var(--font-down-1);
       font-weight: bold;
     }
     .d-icon {
-      font-size: 13px;
+      font-size: var(--font-down-1);
       margin-right: 0.5em;
     }
     a {
       color: var(--primary-low-mid);
-      font-size: 13px;
+      font-size: var(--font-down-1);
       font-weight: bold;
     }
   }

--- a/javascripts/discourse/connectors/topic-list-before-link/topic-thumbnail.hbr
+++ b/javascripts/discourse/connectors/topic-list-before-link/topic-thumbnail.hbr
@@ -1,1 +1,2 @@
 {{~raw "topic-list-thumbnail" topic=context.topic location="before-link"}}
+

--- a/javascripts/discourse/initializers/topic-thumbnails-init.js
+++ b/javascripts/discourse/initializers/topic-thumbnails-init.js
@@ -42,6 +42,23 @@ export default {
       isMasonryList: readOnly("topicThumbnailsService.displayMasonry"),
     });
 
+    if (settings.docs_thumbnail_mode !== "none") {
+      api.modifyClass("component:docs-topic-list", {
+        pluginId: "topic-thumbnails",
+        topicThumbnailsService: service("topic-thumbnails"),
+        classNameBindings: [
+          "isMinimalGrid:topic-thumbnails-minimal",
+          "isThumbnailGrid:topic-thumbnails-grid",
+          "isThumbnailList:topic-thumbnails-list",
+          "isMasonryList:topic-thumbnails-masonry",
+        ],
+        isMinimalGrid: readOnly("topicThumbnailsService.displayMinimalGrid"),
+        isThumbnailGrid: readOnly("topicThumbnailsService.displayGrid"),
+        isThumbnailList: readOnly("topicThumbnailsService.displayList"),
+        isMasonryList: readOnly("topicThumbnailsService.displayMasonry")
+      });
+    }
+
     api.modifyClass("component:topic-list-item", {
       pluginId: "topic-thumbnails",
       topicThumbnailsService: service("topic-thumbnails"),

--- a/javascripts/discourse/initializers/topic-thumbnails-init.js
+++ b/javascripts/discourse/initializers/topic-thumbnails-init.js
@@ -45,7 +45,7 @@ export default {
     });
 
     const siteSettings = api.container.lookup("site-settings:main");
-    
+
     if (settings.docs_thumbnail_mode !== "none" && siteSettings.docs_enabled) {
       api.modifyClass("component:docs-topic-list", {
         pluginId: "topic-thumbnails",

--- a/javascripts/discourse/initializers/topic-thumbnails-init.js
+++ b/javascripts/discourse/initializers/topic-thumbnails-init.js
@@ -35,14 +35,18 @@ export default {
         "isThumbnailGrid:topic-thumbnails-grid",
         "isThumbnailList:topic-thumbnails-list",
         "isMasonryList:topic-thumbnails-masonry",
+        "isBlogStyleGrid:topic-thumbnails-blog-style-grid",
       ],
       isMinimalGrid: readOnly("topicThumbnailsService.displayMinimalGrid"),
       isThumbnailGrid: readOnly("topicThumbnailsService.displayGrid"),
       isThumbnailList: readOnly("topicThumbnailsService.displayList"),
       isMasonryList: readOnly("topicThumbnailsService.displayMasonry"),
+      isBlogStyleGrid: readOnly("topicThumbnailsService.displayBlogStyle"),
     });
 
-    if (settings.docs_thumbnail_mode !== "none") {
+    const siteSettings = api.container.lookup("site-settings:main");
+    
+    if (settings.docs_thumbnail_mode !== "none" && siteSettings.docs_enabled) {
       api.modifyClass("component:docs-topic-list", {
         pluginId: "topic-thumbnails",
         topicThumbnailsService: service("topic-thumbnails"),
@@ -51,11 +55,13 @@ export default {
           "isThumbnailGrid:topic-thumbnails-grid",
           "isThumbnailList:topic-thumbnails-list",
           "isMasonryList:topic-thumbnails-masonry",
+          "isBlogStyleGrid:topic-thumbnails-blog-style-grid",
         ],
         isMinimalGrid: readOnly("topicThumbnailsService.displayMinimalGrid"),
         isThumbnailGrid: readOnly("topicThumbnailsService.displayGrid"),
         isThumbnailList: readOnly("topicThumbnailsService.displayList"),
-        isMasonryList: readOnly("topicThumbnailsService.displayMasonry")
+        isMasonryList: readOnly("topicThumbnailsService.displayMasonry"),
+        isBlogStyleGrid: readOnly("topicThumbnailsService.displayBlogStyle"),
       });
     }
 
@@ -72,7 +78,8 @@ export default {
           wasMobileView &&
           (this.topicThumbnailsService.displayGrid ||
             this.topicThumbnailsService.displayMasonry ||
-            this.topicThumbnailsService.displayMinimalGrid)
+            this.topicThumbnailsService.displayMinimalGrid ||
+            this.topicThumbnailsService.displayBlogStyle)
         ) {
           setResolverOption("mobileView", false);
         }

--- a/javascripts/discourse/raw-views/topic-list-thumbnail.js
+++ b/javascripts/discourse/raw-views/topic-list-thumbnail.js
@@ -38,15 +38,15 @@ export default EmberObject.extend({
     displayBlogStyle
   ) {
     if (
-      (displayGrid || displayMasonry || displayMinimalGrid || displayBlogStyle) &&
+      (displayGrid ||
+        displayMasonry ||
+        displayMinimalGrid ||
+        displayBlogStyle) &&
       location === "before-columns"
     ) {
       return true;
     }
-    if (
-      (displayList)
-       && location === "before-link"
-      ) {
+    if (displayList && location === "before-link") {
       return true;
     }
     return false;
@@ -115,5 +115,5 @@ export default EmberObject.extend({
     return topic.linked_post_number
       ? topic.urlForPostNumber(topic.linked_post_number)
       : topic.get("lastUnreadUrl");
-  }
+  },
 });

--- a/javascripts/discourse/raw-views/topic-list-thumbnail.js
+++ b/javascripts/discourse/raw-views/topic-list-thumbnail.js
@@ -26,6 +26,7 @@ export default EmberObject.extend({
     "topicThumbnailsService.displayGrid",
     "topicThumbnailsService.displayList",
     "topicThumbnailsService.displayMasonry",
+    "topicThumbnailsService.displayBlogStyle"
   )
   enabledForOutlet(
     location,
@@ -33,10 +34,11 @@ export default EmberObject.extend({
     displayMinimalGrid,
     displayGrid,
     displayList,
-    displayMasonry
+    displayMasonry,
+    displayBlogStyle
   ) {
     if (
-      (displayGrid || displayMasonry || displayMinimalGrid) &&
+      (displayGrid || displayMasonry || displayMinimalGrid || displayBlogStyle) &&
       location === "before-columns"
     ) {
       return true;
@@ -110,5 +112,5 @@ export default EmberObject.extend({
     return topic.linked_post_number
       ? topic.urlForPostNumber(topic.linked_post_number)
       : topic.get("lastUnreadUrl");
-  },
+  }
 });

--- a/javascripts/discourse/raw-views/topic-list-thumbnail.js
+++ b/javascripts/discourse/raw-views/topic-list-thumbnail.js
@@ -25,7 +25,7 @@ export default EmberObject.extend({
     "topicThumbnailsService.displayMinimalGrid",
     "topicThumbnailsService.displayGrid",
     "topicThumbnailsService.displayList",
-    "topicThumbnailsService.displayMasonry"
+    "topicThumbnailsService.displayMasonry",
   )
   enabledForOutlet(
     location,

--- a/javascripts/discourse/raw-views/topic-list-thumbnail.js
+++ b/javascripts/discourse/raw-views/topic-list-thumbnail.js
@@ -43,7 +43,10 @@ export default EmberObject.extend({
     ) {
       return true;
     }
-    if (displayList && location === "before-link") {
+    if (
+      (displayList)
+       && location === "before-link"
+      ) {
       return true;
     }
     return false;

--- a/javascripts/discourse/services/topic-thumbnails.js
+++ b/javascripts/discourse/services/topic-thumbnails.js
@@ -18,10 +18,15 @@ const masonryCategories = settings.masonry_categories
   .split("|")
   .map((id) => parseInt(id, 10));
 
+const blogStyleCategories = settings.blog_style_categories
+  .split("|")
+  .map((id) => parseInt(id, 10));
+
 const minimalGridTags = settings.minimal_grid_tags.split("|");
 const listTags = settings.list_tags.split("|");
 const gridTags = settings.grid_tags.split("|");
 const masonryTags = settings.masonry_tags.split("|");
+const blogStyleTags = settings.blog_style_tags.split("|");
 
 export default Service.extend({
   router: service("router"),
@@ -88,6 +93,8 @@ export default Service.extend({
     }
     if (minimalGridCategories.includes(viewingCategoryId)) {
       return "minimal-grid";
+    } else if (blogStyleCategories.includes(viewingCategoryId)) {
+      return "blog-style";
     } else if (masonryCategories.includes(viewingCategoryId)) {
       return "masonry";
     } else if (gridCategories.includes(viewingCategoryId)) {
@@ -98,11 +105,13 @@ export default Service.extend({
       return "masonry";
     } else if (minimalGridTags.includes(viewingTagId)) {
       return "minimal-grid";
+    } else if (blogStyleTags.includes(viewingTagId)) {
+      return "blog-style";
     } else if (gridTags.includes(viewingTagId)) {
       return "grid";
     } else if (listTags.includes(viewingTagId)) {
       return "list";
-    } else if (isTopicRoute && settings.suggested_topics_mode) {
+    }  else if (isTopicRoute && settings.suggested_topics_mode) {
       return settings.suggested_topics_mode;
     } else if (isTopicListRoute || settings.enable_outside_topic_lists) {
       return settings.default_thumbnail_mode;
@@ -147,4 +156,14 @@ export default Service.extend({
   displayMasonry(shouldDisplay, displayMode) {
     return shouldDisplay && displayMode === "masonry";
   },
+
+  @discourseComputed("shouldDisplay", "displayMode")
+  displayBlogStyle(shouldDisplay, displayMode) {
+    return shouldDisplay && displayMode === "blog-style";
+  },
+
+  @discourseComputed("displayMinimalGrid", "displayBlogStyle")
+  showLikes(isMinimalGrid, isBlogStyle) {
+    return isMinimalGrid || isBlogStyle;
+  }
 });

--- a/javascripts/discourse/services/topic-thumbnails.js
+++ b/javascripts/discourse/services/topic-thumbnails.js
@@ -39,6 +39,11 @@ export default Service.extend({
     return currentRouteName.match(/^topic\./);
   },
 
+  @discourseComputed("router.currentRouteName")
+  isDocsRoute(currentRouteName) {
+    return currentRouteName.match(/^docs\./);
+  },
+
   @discourseComputed(
     "router.currentRouteName",
     "router.currentRoute.attributes.category.id"
@@ -67,14 +72,16 @@ export default Service.extend({
     "viewingTagId",
     "router.currentRoute.metadata.customThumbnailMode",
     "isTopicListRoute",
-    "isTopicRoute"
+    "isTopicRoute",
+    "isDocsRoute"
   )
   displayMode(
     viewingCategoryId,
     viewingTagId,
     customThumbnailMode,
     isTopicListRoute,
-    isTopicRoute
+    isTopicRoute,
+    isDocsRoute
   ) {
     if (customThumbnailMode) {
       return customThumbnailMode;
@@ -99,6 +106,8 @@ export default Service.extend({
       return settings.suggested_topics_mode;
     } else if (isTopicListRoute || settings.enable_outside_topic_lists) {
       return settings.default_thumbnail_mode;
+    } else if (isDocsRoute) {
+      return settings.docs_thumbnail_mode;
     } else {
       return "none";
     }

--- a/javascripts/discourse/services/topic-thumbnails.js
+++ b/javascripts/discourse/services/topic-thumbnails.js
@@ -163,7 +163,7 @@ export default Service.extend({
   },
 
   @discourseComputed("displayMinimalGrid", "displayBlogStyle")
-  showLikes(isMinimalGrid, isBlogStyle) {
-    return isMinimalGrid || isBlogStyle;
+  showLikes(isMinimalGrid) {
+    return isMinimalGrid;
   }
 });

--- a/javascripts/discourse/services/topic-thumbnails.js
+++ b/javascripts/discourse/services/topic-thumbnails.js
@@ -111,7 +111,7 @@ export default Service.extend({
       return "grid";
     } else if (listTags.includes(viewingTagId)) {
       return "list";
-    }  else if (isTopicRoute && settings.suggested_topics_mode) {
+    } else if (isTopicRoute && settings.suggested_topics_mode) {
       return settings.suggested_topics_mode;
     } else if (isTopicListRoute || settings.enable_outside_topic_lists) {
       return settings.default_thumbnail_mode;
@@ -165,5 +165,5 @@ export default Service.extend({
   @discourseComputed("displayMinimalGrid", "displayBlogStyle")
   showLikes(isMinimalGrid) {
     return isMinimalGrid;
-  }
+  },
 });

--- a/javascripts/discourse/templates/topic-list-thumbnail.hbr
+++ b/javascripts/discourse/templates/topic-list-thumbnail.hbr
@@ -31,7 +31,7 @@
       </a>
   </div>
 
-  {{#if view.topicThumbnailsService.displayMinimalGrid}}
+  {{#if view.topicThumbnailsService.showLikes}}
     <div class="topic-thumbnail-likes">
       {{d-icon "heart"}}
       <span class="number">

--- a/javascripts/discourse/templates/topic-list-thumbnail.hbr
+++ b/javascripts/discourse/templates/topic-list-thumbnail.hbr
@@ -39,4 +39,28 @@
       </span>
     </div>
   {{/if}}
+
+  {{#if view.topicThumbnailsService.displayBlogStyle}}
+    <div class="topic-thumbnail-blog-data">
+      <div class="topic-thumbnail-blog-data-views">
+        {{d-icon "eye"}}
+        <span class="number">
+          {{view.topic.views}}
+        </span>
+      </div>
+      <div class="topic-thumbnail-blog-data-likes">
+        {{d-icon "heart"}}
+        <span class="number">
+          {{view.topic.like_count}}
+        </span>
+      </div>
+      <div class="topic-thumbnail-blog-data-comments">
+        {{d-icon "comment"}}
+        <span class="number">
+          {{view.topic.reply_count}}
+        </span>
+      </div>
+      {{raw "list/activity-column" topic=view.topic class="topic-thumbnail-blog-data-activity" tagName="div"}}
+    </div>
+  {{/if}}
 {{/if}}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3,6 +3,8 @@ en:
     description: Theme component which adds thumbnails to topic lists. You can enable it globally, or per-category
     settings:
       default_thumbnail_mode: Which thumbnail display mode should be used by default?
+      docs_thumbnail_mode: If the docs plugin is enabled, which thumbnail display mode should be used for docs topics?
+      blog_style_categories: The blog-style view will be used in these categories. This style makes use of topic-excerpts if enabled via theme or theme component.
       minimal_grid_categories: The minimal grid view will be used in these categories
       grid_categories: The grid view will be used in these categories
       masonry_categories: The masonry view will be used in these categories

--- a/settings.yml
+++ b/settings.yml
@@ -6,6 +6,7 @@ default_thumbnail_mode:
     - grid
     - masonry
     - list
+    - blog-style
     - none
 
 docs_thumbnail_mode:
@@ -17,6 +18,11 @@ docs_thumbnail_mode:
     - list
     - blog-style
     - none
+
+blog_style_categories:
+  type: list
+  list_type: category
+  default: ""
 
 minimal_grid_categories:
   type: list
@@ -36,6 +42,11 @@ masonry_categories:
 list_categories:
   type: list
   list_type: category
+  default: ""
+
+blog_style_tags:
+  type: list
+  list_type: tag
   default: ""
 
 minimal_grid_tags:
@@ -67,6 +78,7 @@ suggested_topics_mode:
     - grid
     - masonry
     - list
+    - blog-style
     - none
 
 enable_outside_topic_lists: false

--- a/settings.yml
+++ b/settings.yml
@@ -8,6 +8,16 @@ default_thumbnail_mode:
     - list
     - none
 
+docs_thumbnail_mode:
+  default: none
+  type: enum
+  choices:
+    - minimal-grid
+    - grid
+    - list
+    - blog-style
+    - none
+
 minimal_grid_categories:
   type: list
   list_type: category


### PR DESCRIPTION
This PR adds a new stye to the topic thumbnails options, the blog style.

<img width="866" alt="image" src="https://github.com/discourse/discourse-topic-thumbnails/assets/30537603/cdcd9a62-f58a-4289-b57a-b125f31b84b4">

Works well with the topic-list excerpts component as well.

<img width="700" alt="image" src="https://github.com/discourse/discourse-topic-thumbnails/assets/30537603/4a5d0199-a9ba-4d01-8abe-39f669a151b2">


