### PR TITLE
FIX: Allow switching to/from masonry mode with loading slider

### DIFF
--- a/javascripts/discourse/initializers/topic-thumbnails-init.js
+++ b/javascripts/discourse/initializers/topic-thumbnails-init.js
@@ -121,9 +121,6 @@ export default {
 
       didInsertElement() {
         this._super();
-        if (!this.topicThumbnailsService.displayMasonry) {
-          return;
-        }
         this.updateElementHeight();
 
         if (window.ResizeObserver) {


### PR DESCRIPTION
Having a check for `displayMasonry` in the topic-list component `didInsertElement` hook is problematic because, under the loading slider, the topic-list component may be re-used across different routes. Instead, we can set up the resizeObserver unconditionally. It's cheap to set up, and it only has an effect on topic lists which actually have masonry mode enabled.