### PR TITLE
Masonry height adjustment

### DIFF
--- a/javascripts/discourse/initializers/topic-thumbnails-init.js
+++ b/javascripts/discourse/initializers/topic-thumbnails-init.js
@@ -206,7 +206,7 @@ export default {
       tagHeight = 66;
     }
 
-    let bottomHeight = 45;
+    let bottomHeight = 65;
 
     let extraHeight = titleHeight + tagHeight + bottomHeight;
 

--- a/javascripts/discourse/initializers/topic-thumbnails-init.js
+++ b/javascripts/discourse/initializers/topic-thumbnails-init.js
@@ -165,6 +165,9 @@ export default {
         }
 
         this.filteredTopics.forEach((topic) => {
+
+          console.log(topic);
+
           // Pick the column with the lowest height
           const smallestColumn = columnHeights.indexOf(
             Math.min(...columnHeights)
@@ -179,7 +182,7 @@ export default {
 
           // Add more height when there is more text
           let extraHeight = topic.title.length * 3
-          
+
           const thisHeight =
             this.masonryColumnWidth / aspect + extraHeight;
 

--- a/javascripts/discourse/initializers/topic-thumbnails-init.js
+++ b/javascripts/discourse/initializers/topic-thumbnails-init.js
@@ -197,13 +197,13 @@ export default {
     let tagCharacters = topic.tags.join();
 
     if (tagCharacters <= 30) {
-      tagHeight = 20;
+      tagHeight = 22;
     }
     else if (tagCharacters > 60) {
-      tagHeight = 40;
+      tagHeight = 44;
     }
     else if (tagCharacters > 90) {
-      tagHeight = 60;
+      tagHeight = 66;
     }
 
     let bottomHeight = 45;

--- a/javascripts/discourse/initializers/topic-thumbnails-init.js
+++ b/javascripts/discourse/initializers/topic-thumbnails-init.js
@@ -180,11 +180,38 @@ export default {
           }
           aspect = Math.max(aspect, this.masonryMinAspect);
 
-          // Add more height when there is more text
-          let extraHeight = topic.title.length * 3
+    // Change height with title variation
+    let titleHeight = 50;
 
-          const thisHeight =
-            this.masonryColumnWidth / aspect + extraHeight;
+    if (topic.title.length > 90) {
+      titleHeight = 125;
+    } else if (topic.title.length > 60) {
+      titleHeight = 100;
+    } else if (topic.title.length > 30) {
+      titleHeight = 75;
+    }
+
+    // Change height with tag variation
+    let tagHeight = 0;
+
+    let tagCharacters = topic.tags.join();
+
+    if (tagCharacters <= 45) {
+      tagHeight = 20;
+    }
+    else if (tagCharacters > 90) {
+      tagHeight = 40;
+    }
+    else if (tagCharacters > 135) {
+      tagHeight = 60;
+    }
+
+    let bottomHeight = 45;
+
+    let extraHeight = titleHeight + tagHeight + bottomHeight;
+
+    const thisHeight =
+      this.masonryColumnWidth / aspect + extraHeight;
 
           topic.set("masonryData", {
             columnIndex: smallestColumn,

--- a/javascripts/discourse/initializers/topic-thumbnails-init.js
+++ b/javascripts/discourse/initializers/topic-thumbnails-init.js
@@ -176,8 +176,12 @@ export default {
             aspect = topic.thumbnails[0].width / topic.thumbnails[0].height;
           }
           aspect = Math.max(aspect, this.masonryMinAspect);
+
+          // Add more height when there is more text
+          let extraHeight = topic.title.length * 3
+          
           const thisHeight =
-            this.masonryColumnWidth / aspect + this.masonryTitleSpacePixels;
+            this.masonryColumnWidth / aspect + extraHeight;
 
           topic.set("masonryData", {
             columnIndex: smallestColumn,

--- a/javascripts/discourse/initializers/topic-thumbnails-init.js
+++ b/javascripts/discourse/initializers/topic-thumbnails-init.js
@@ -196,13 +196,13 @@ export default {
 
     let tagCharacters = topic.tags.join();
 
-    if (tagCharacters <= 45) {
+    if (tagCharacters <= 30) {
       tagHeight = 20;
     }
-    else if (tagCharacters > 90) {
+    else if (tagCharacters > 60) {
       tagHeight = 40;
     }
-    else if (tagCharacters > 135) {
+    else if (tagCharacters > 90) {
       tagHeight = 60;
     }
 

--- a/javascripts/discourse/initializers/topic-thumbnails-init.js
+++ b/javascripts/discourse/initializers/topic-thumbnails-init.js
@@ -166,8 +166,6 @@ export default {
 
         this.filteredTopics.forEach((topic) => {
 
-          console.log(topic);
-
           // Pick the column with the lowest height
           const smallestColumn = columnHeights.indexOf(
             Math.min(...columnHeights)


### PR DESCRIPTION
This is a workaround for Thumbnails disappearing when the Title text, and tags take up more than one line. 

The masonryHeight is being set without the size of the Text being considered. I couldn't seem to coordinate the height of the Text box via offsetHeight, so in an attempt to get a quick fix, I'm basing the height adjustments on the character count. Character count is not a consistent value to base the measurement on, however, for the moment this solves our problem with the Thumbnails shrinking when the title text extends longer than one line.

