### PR TITLE
UX: prevent background overflow

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -128,7 +128,6 @@
     top: 0;
     left: 0;
     grid-area: image;
-    overflow: visible;
     .background-thumbnail {
       height: calc(150%);
     }


### PR DESCRIPTION
Fixes an issue where the blur on portrait image backgrounds overflows the container

Before:
![image](https://github.com/user-attachments/assets/e0a2d231-78c5-4db7-a1e6-2dd4c2721ea3)

After:
![image](https://github.com/user-attachments/assets/5027cefa-7abc-46e8-9615-45f758d4c359)
