### PR TITLE
UX: Fix spacing in comments grid

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -259,7 +259,7 @@
   .topic-thumbnail-likes {
     grid-area: likes;
     display: flex;
-    justify-content: flex-end;
+    justify-content: center;
     align-items: center;
     color: var(--primary-low-mid);
     overflow: hidden;
@@ -280,8 +280,6 @@
     width: auto !important; // overrides very specific core style
     .badge-posts {
       padding: 0;
-      height: 100%;
-      width: 100%;
     }
     span.number {
       color: var(--primary-low-mid);


### PR DESCRIPTION
This PR removes some height & width settings that were breaking the minimal topic list grid view.

**After**
![CleanShot 2024-12-24 at 07 47 57@2x](https://github.com/user-attachments/assets/554696bd-8328-4b1c-b11a-7a8b33dcab6c)

**Before**
![CleanShot 2024-12-24 at 07 48 34@2x](https://github.com/user-attachments/assets/981615c6-1549-4e19-8b6d-68d41e90577c)
