### PR TITLE
A11Y: link missing accessible name

### DIFF
--- a/javascripts/discourse/components/topic-list-thumbnail.gjs
+++ b/javascripts/discourse/components/topic-list-thumbnail.gjs
@@ -89,7 +89,7 @@ export default class TopicListThumbnail extends Component {
         (if this.hasThumbnail "has-thumbnail" "no-thumbnail")
       }}
     >
-      <a href={{this.url}}>
+      <a href={{this.url}} aria-label={{this.topic.title}}>
         {{#if this.hasThumbnail}}
           <img
             class="background-thumbnail"


### PR DESCRIPTION
## What is the problem

Link missing accessible name.

## Description

One or more A elements, without an ARIA-assigned role, not intentionally hidden in the DOM and available to assistive technologies, does not have a mechanism that allows an accessible name value to be calculated.

## Why it matters

When a link's purpose cannot be determined, users may be required to follow the link to determine its purpose. Returning to a previous location can often be more difficult for users with disabilities using assistive technology. Thus, authors must ensure that a link's purpose is clear within context.

## What to do

Ensure the accessible name of each link accurately reflects the target and purpose of the link when the link and its surrounding text is taken into context. This can be done by changing text that is used to calculate a link's accessible name, or by modifying text before the link, such as in the same sentence, paragraph, list item, etc. Even when combined with text in context, it may still be helpful to users of screen readers to provide an accessible link name that makes the link's purpose clear out of context. If the accessible name of the link cannot be updated, authors should ensure that the content surrounding the link aids in identifying the links purpose. Acceptable methods of providing purpose via link context includes indicating the purpose in the same:

1. Sentence, paragraph, or list item or
2. Table cell as the link or
3. In the table header cell for a link in a data table

